### PR TITLE
Document `https` submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Then add it as submodule of your repository:
 ```
 git submodule add git@github.com:humrochagf/colordrop.git themes/colordrop
 ```
+OR
+```
+git submodule add https://github.com/humrochagf/colordrop.git themes/colordrop
+```
 
 And add this configuration to your blog config.
 


### PR DESCRIPTION
Some services, like Netlify, do not support SSH git urls.