### PR TITLE
Handle missing blog images and add attribution

### DIFF
--- a/assets/sass/_global.scss
+++ b/assets/sass/_global.scss
@@ -38,7 +38,15 @@ main {
   }
 
   article .list-image {
-    width: 100%;
+    img {
+      width: 100%;
+    }
+
+    .attribution {
+      font-size: smaller;
+      text-align: center;
+    }
+
     margin: 0 0 20px;
   }
 

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -13,7 +13,27 @@
 
       {{ partial "publish" . }}
 
-      <img class="list-image" src="{{ index .Params.images 0 | safeURL }}" alt="{{ .Title }}" title="{{ .Title }}" />
+      {{ if and
+        (ne nil .Params.images)
+        (ne nil (index .Params.images 0))
+      }}
+        <div class="list-image">
+          {{ $image := index .Params.images 0 }}
+          <a href="{{ .Permalink }}">
+            <img
+              src="{{ $image.src | safeURL }}"
+              alt="{{ .Title }}"
+              title="{{ .Title }}"
+            />
+          </a>
+
+          {{ if ne nil $image.attribution }}
+            <div class="attribution">
+              {{ print $image.attribution | safeHTML }}
+            </div>
+          {{ end }}
+        </div>
+      {{ end }}
 
       {{ .Summary }}
     </article>

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -13,7 +13,27 @@
 
       {{ partial "publish" . }}
 
-      <img class="list-image" src="{{ index .Params.images 0 | safeURL }}" alt="{{ .Title }}" title="{{ .Title }}" />
+      {{ if and
+        (ne nil .Params.images)
+        (ne nil (index .Params.images 0))
+      }}
+        <div class="list-image">
+          {{ $image := index .Params.images 0 }}
+          <a href="{{ .Permalink }}">
+            <img
+              src="{{ $image.src | safeURL }}"
+              alt="{{ .Title }}"
+              title="{{ .Title }}"
+            />
+          </a>
+
+          {{ if ne nil $image.attribution }}
+            <div class="attribution">
+              {{ print $image.attribution | safeHTML }}
+            </div>
+          {{ end }}
+        </div>
+      {{ end }}
 
       {{ .Summary }}
     </article>


### PR DESCRIPTION
If an article doesn't have an array of images, or if the array is empty, the list and taxonomy either fails or breaks.

This PR changes the list images to be conditional on the presence and adds an attribution element as well.