### PR TITLE
Added fix for title for home page.

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -7,7 +7,7 @@
     {{ end }}
 
     <!-- Page title -->
-    <title>{{ .Title }} - {{ .Site.Title }}</title>
+    <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} - {{ .Site.Title }}{{ end }}</title>
 
     <!-- styles -->
     {{ $style := resources.Get "sass/main.scss" | resources.ExecuteAsTemplate "style.main.scss" . | css.Sass | resources.Minify | resources.Fingerprint }}


### PR DESCRIPTION
For the home page the title is {{ .Title }} - {{ .Site.Title }} which translates to a double name. E.g: `Radu Ghiorghisor - Radu Ghiorghisor` or `Humberto Rocha - Humberto Rocha`. This fix will only use one.

Bonus: The Google results will look nicer 😄! 

Let me know what you think!